### PR TITLE
update networkx graph references to support 2.x API

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 build: off
 
 cache:
-  - %MINICONDA%\envs\test-env
+  - "%MINICONDA%\\envs\\test-env"
 
 test_script:
   - pytest %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
-  - conda create -n test-env python=%PYTHON_VERSION% geopandas==0.10.2
+  - conda create -n test-env python=%PYTHON_VERSION% geopandas==0.6.1
   - activate test-env
   - python setup.py develop
   - pip install -r %APPVEYOR_BUILD_FOLDER%\\requirements.txt -q

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 build: off
 
 cache:
- - %MINICONDA%\envs\test-env
+  - %MINICONDA%\envs\test-env
 
 test_script:
   - pytest %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,23 @@
-#matrix:
-#  fast_finish: true
-
-#branches:
-#  only:
-#    - master
-#    - /dev-.*/
 
 environment:
   matrix:
-    # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
-    # The list here is complete (excluding Python 2.6, which
-    # isn't covered by this document) at the time of writing.
-    # - PYTHON: "C:\\Python36"
-    # - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Miniconda36-x64"
-    - PYTHON: "C:\\Miniconda36"
-    # - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37"
+      MINICONDA: "C:\\Miniconda37"
+      PYTHON_VERSION: 3.7
 
 install:
-  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - conda config --add channels conda-forge
-  - conda install -c conda-forge geopandas -y
-  - "%PYTHON%\\python setup.py develop"
-  - "%PYTHON%\\python.exe -m pip install -r %APPVEYOR_BUILD_FOLDER%\\requirements.txt -q"
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+  - conda create -n test-env python=%PYTHON_VERSION% geopandas==0.10.2
+  - activate test-env
+  - python setup.py develop
+  - pip install -r %APPVEYOR_BUILD_FOLDER%\\requirements.txt -q
 
 build: off
 
 test_script:
-
-  - "%PYTHON%\\Scripts\\pytest %APPVEYOR_BUILD_FOLDER%"
+  - pytest %APPVEYOR_BUILD_FOLDER%
 
   # Asserting pep8 formatting checks (using autopep8 tool)
   # - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - conda create -n test-env python=%PYTHON_VERSION% geopandas==0.6.1
   - activate test-env
   - python setup.py develop
-  - pip install -r %APPVEYOR_BUILD_FOLDER%\\requirements.txt -q
+  - python -m pip install -r %APPVEYOR_BUILD_FOLDER%\\requirements.txt -q
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,9 @@ install:
 
 build: off
 
+cache:
+ - %MINICONDA%\envs\test-env
+
 test_script:
   - pytest %APPVEYOR_BUILD_FOLDER%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ install:
 
 build: off
 
-cache:
-  - "%MINICONDA%\\envs\\test-env"
-
 test_script:
   - pytest %APPVEYOR_BUILD_FOLDER%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,3 +30,14 @@ test_script:
   #         Please this command locally:
   #         'autopep8 -i -a -r .'"
   #     }
+
+on_success:
+  - >
+    IF "%APPVEYOR_REPO_TAG%" == "true"
+    (
+    pip install wheel &&
+    python setup.py bdist_wheel &&
+    pip install twine &&
+    twine upload dist/* -u "%PYPI_USERNAME%" -p "%PYPI_PASSWORD%"
+    )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+geopandas==0.10.2
+networkx==2.6.3
+ogr==0.37.0
+geojson==2.5.0
+
 # Build dependencies
 pytest
 autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 geopandas==0.10.2
 networkx==2.6.3
-ogr==0.37.0
 geojson==2.5.0
 
-# Build dependencies
+# dependencies for tests
 pytest
 autopep8
-
-# Run dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-geopandas==0.10.2
+geopandas==0.6.1
 networkx==2.6.3
 geojson==2.5.0
 

--- a/sewergraph/__init__.py
+++ b/sewergraph/__init__.py
@@ -9,7 +9,7 @@ from .core import *
 from .helpers import *
 from .area_calcs import *
 from .resolve_data import *
-from sewergraph.save_load import graph_from_shp, gdf_from_graph, graph_from_gdf
+from sewergraph.save_load import graph_from_shp, gdf_from_graph, graph_from_gdf, graph_from_gdfs
 
 VERSION_INFO = (0, 1, 2)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/sewergraph/__init__.py
+++ b/sewergraph/__init__.py
@@ -11,7 +11,7 @@ from .area_calcs import *
 from .resolve_data import *
 from sewergraph.save_load import graph_from_shp, gdf_from_graph, graph_from_gdf, graph_from_gdfs
 
-VERSION_INFO = (0, 1, 2)
+VERSION_INFO = (0, 1, 3, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))
 __author__ = 'Adam Erispaha'
 __copyright__ = 'Copyright (c) 2017 Adam Erispaha'

--- a/sewergraph/area_calcs.py
+++ b/sewergraph/area_calcs.py
@@ -16,7 +16,7 @@ def map_area_to_sewers(G, areas, idcol='facilityid'):
     # a = a.join(sewerids)
     # a = a.set_index(['source', 'target'])[['local_area']].T.apply(tuple).to_dict('records')[0]
     s1 = sewerids.set_index(idcol).join(a)
-    local_areas = {(row.source,row.target):row.local_area for id, row in s1.iterrows()}
+    local_areas = {(row.source, row.target): row.local_area for k, row in s1.iterrows()}
     nx.set_edge_attributes(G, local_areas, 'local_area')
 
 
@@ -38,7 +38,7 @@ def drainage_areas_from_sewers(sewersdf, SEWER_ID_COL, study_area=None,
         ImportError('scipy.spatial, GeoPandas, and shapely are required for drainage_areas_from_sewers')
 
     in_crs = sewersdf.crs
-    working_crs = {'init':'epsg:2272'}
+    working_crs = 'epsg:2272'
     #convert to state plane so we can get lengths in feet
     #include only sewers of the minumum desired length
     sewersdf1 = sewersdf.to_crs(working_crs)
@@ -51,7 +51,7 @@ def drainage_areas_from_sewers(sewersdf, SEWER_ID_COL, study_area=None,
     #create points spaced at 10 feet of sewer
     pts = [
         (sewer.interpolate(pt).x, sewer.interpolate(pt).y)
-        for sewer in sewer_shapes
+        for sewer in sewer_shapes.geoms
         for pt in np.arange(0, sewer.length, 10.)
     ]
 

--- a/sewergraph/area_calcs.py
+++ b/sewergraph/area_calcs.py
@@ -1,16 +1,16 @@
-import pandas as pd
-import numpy as np
 import os
-import networkx as nx
 from functools import reduce
 
+import pandas as pd
+import numpy as np
+import networkx as nx
+
 import sewergraph as sg
-import sewergraph.save_load
 
 
 def map_area_to_sewers(G, areas, idcol='facilityid'):
     a = areas.set_index(idcol)
-    sewers = sewergraph.save_load.gdf_from_graph(G)
+    sewers = sg.gdf_from_graph(G)
     sewerids = sewers[[idcol, 'source', 'target']]
 
     # a = a.join(sewerids)

--- a/sewergraph/area_calcs.py
+++ b/sewergraph/area_calcs.py
@@ -16,7 +16,7 @@ def map_area_to_sewers(G, areas, idcol='facilityid'):
     # a = a.join(sewerids)
     # a = a.set_index(['source', 'target'])[['local_area']].T.apply(tuple).to_dict('records')[0]
     s1 = sewerids.set_index(idcol).join(a)
-    local_areas = {(row.source, row.target): row.local_area for k, row in s1.iterrows()}
+    local_areas = {(row.source, row.target, k): row.local_area for k, row in s1.iterrows()}
     nx.set_edge_attributes(G, local_areas, 'local_area')
 
 

--- a/sewergraph/core.py
+++ b/sewergraph/core.py
@@ -67,16 +67,15 @@ def accumulate_downstream(G, accum_attr='local_area', cumu_attr_name=None,
 
         # sum with cumulative values in upstream nodes and edges
         for p in G1.predecessors(n):
-            for k in G1[p][n]:
 
-                # add cumulative attribute val in upstream node, apply flow split fraction
-                attrib_val += G1.nodes[p][cumu_attr_name] * G1[p][n][k].get(split_attr, 1)
+            # add cumulative attribute val in upstream node, apply flow split fraction
+            attrib_val += G1.nodes[p][cumu_attr_name] * G1[p][n].get(split_attr, 1)
 
-                # add area routed directly to upstream edge/sewer
-                attrib_val += G1[p][n][k].get(accum_attr, 0)
+            # add area routed directly to upstream edge/sewer
+            attrib_val += G1[p][n].get(accum_attr, 0)
 
-                # store cumulative value in upstream edge
-                G1.edges[(p, n, k)][cumu_attr_name] = attrib_val
+            # store cumulative value in upstream edge
+            G1[p][n][cumu_attr_name] = attrib_val
 
         # store cumulative attribute value in current node
         G1.nodes[n][cumu_attr_name] = attrib_val

--- a/sewergraph/core.py
+++ b/sewergraph/core.py
@@ -388,14 +388,16 @@ def find_edge(G, facilityid):
 
 
 def set_flow_direction(G1, out):
-    '''
-    THATS THE ONEEEEEEE BOIIIIII
-    '''
+    """
+    Set the flow direction in a MultiDiGraph.
+
+    Logic summary:
+    For each node in an undirected copy of G,
+    find edges in the simple short paths from n to all outs
+    that don't exist in G, then reverse them
+    """
     H1 = G1.to_undirected()
 
-    # for each node in an undirected copy of G,
-    # find edges in the simple short paths from n to all outs
-    # that don't exist in G, then reverse them
     rev_edges = []
     for n in H1.nodes():
         if nx.has_path(H1, n, out):

--- a/sewergraph/helpers.py
+++ b/sewergraph/helpers.py
@@ -23,7 +23,7 @@ def open_file(filename):
 def sum_params_in_nodes(G, nodes, parameter):
     """Sum the returned value of each parameter for all nodes
     having the parameter, in network G"""
-    vals = [G.node[n][parameter] for n in nodes if parameter in G.node[n]]
+    vals = [G.nodes[n][parameter] for n in nodes if parameter in G.nodes[n]]
     return sum(vals)
 
 def data_from_adjacent_node(G, n, key='facilityid'):
@@ -45,8 +45,8 @@ def get_node_values(G, nodes, parameters):
     """return a list of values in nodes having the parameter"""
 
     #if the parameter is in the node, return its value
-    upstream_vals = [G.node[n][p] for n in nodes
-                      for p in parameters if p in G.node[n]]
+    upstream_vals = [G.nodes[n][p] for n in nodes
+                      for p in parameters if p in G.nodes[n]]
 
     return upstream_vals
 
@@ -147,6 +147,6 @@ def transform_projection(G, to_crs='epsg:4326'):
 
     for n, geometry in G.nodes(data='geometry'):
         if geometry:
-            G.node[n]['geometry'] = transform(project, geometry)
+            G.nodes[n]['geometry'] = transform(project, geometry)
 
     G.graph['crs'] = to_crs

--- a/sewergraph/hhcalculations.py
+++ b/sewergraph/hhcalculations.py
@@ -83,7 +83,7 @@ def mannings_capacity(diameter, slope, height=None, width=None, shape="CIR"):
 	n = get_mannings(shape, diameter)
 	k = (1.49 / n) * math.pow(Rh, 0.667) * A
 
-	Q = k * math.pow(slope/100.0, 0.5)
+	Q = k * math.pow(slope, 0.5)
 
 	return Q
 

--- a/sewergraph/hhcalculations.py
+++ b/sewergraph/hhcalculations.py
@@ -1,5 +1,6 @@
 import math
 
+
 def hhcalcs_on_network(G):
 	"""
 	For each sewer (edge) in the network, G, calculate the velocity of gravity
@@ -15,7 +16,7 @@ def hhcalcs_on_network(G):
 	"""
 	G1 = G.copy()
 
-	for u,v, data in G1.edges(data=True):
+	for u, v, data in G1.edges(data=True):
 
 		#velocity
 		# diameter = max( data['diameter'], data['height'])
@@ -51,6 +52,7 @@ def hhcalcs_on_network(G):
 
 	return G1
 
+
 def slope_at_velocity(velocity, diameter, height=None, width=None, shape="CIR"):
 	Rh = hydraulic_radius(shape, diameter, height, width)
 	n = get_mannings(shape, diameter)
@@ -58,6 +60,7 @@ def slope_at_velocity(velocity, diameter, height=None, width=None, shape="CIR"):
 
 	slope = (velocity / k) ** 2
 	return slope
+
 
 def mannings_velocity(diameter, slope, height=None, width=None, shape="CIR", data=None):
 

--- a/sewergraph/plot.py
+++ b/sewergraph/plot.py
@@ -13,7 +13,7 @@ def plot_profile(G, path):
 
     for u,v,d in G.edges(data=True, nbunch=path):
 
-        node = G.node[u]
+        node = G.nodes[u]
         sewer = G[u][v]
         inverts.append(node['invert'])
         h = max(sewer['diameter'], sewer['height']) / 12.0

--- a/sewergraph/resolve_data.py
+++ b/sewergraph/resolve_data.py
@@ -121,11 +121,11 @@ def dfs_nodes_attributes_iter(G, source=None, attribute=None, upstream=True,
             parents, child = stack[-1]
             try:
                 parent = next(parents)
-                node = G.node[parent]
+                node = G.nodes[parent]
                 if attribute in node and node[attribute] is not null_val:
                     # by not appending to the search stack, this reach is no
                     # longer traversed
-                    yield (parent, node)
+                    yield parent, node
                 else:
                     # keep searching
                     if upstream:
@@ -211,13 +211,13 @@ def determine_slope_from_adjacent_inverts(G, u, v, data_key='ELEVATIONI'):
             return None, None
 
     # first, check if trusted invs exist in u or v, else find trusted inverts up/dwn
-    if data_key in G.node[u]:
-        up_inv, i = G.node[u][data_key], u
+    if data_key in G.nodes[u]:
+        up_inv, i = G.nodes[u][data_key], u
     else:
         up_inv, i = adjacent_inv(G, u, data_key, upstream=True)
 
-    if data_key in G.node[v]:
-        dn_inv, j = G.node[v][data_key], v
+    if data_key in G.nodes[v]:
+        dn_inv, j = G.nodes[v][data_key], v
     else:
         dn_inv, j = adjacent_inv(G, v, data_key, upstream=False)
 
@@ -389,7 +389,7 @@ def assign_inverts(G, data_key='ELEVATIONI'):
             # fill invert values where nodes already have trusted invert vals
             if G1.node[n].get('invert_trusted', 0) != 0:
                 el_0 = G1.node[n]['invert_trusted']
-                G.node[n]['invert'] = el_0
+                G.nodes[n]['invert'] = el_0
             if G1.node[p].get('invert_trusted', 0) != 0:
                 el_2 = G1.node[p]['invert_trusted']
 

--- a/sewergraph/save_load.py
+++ b/sewergraph/save_load.py
@@ -180,7 +180,9 @@ def graph_from_gdfs(links, nodes=None, upstream_node_field='InletNode', downstre
 
     # create a nx.MultiDiGraph from the combined model links, add node data, set CRS
     G = multidigraph_from_edges(links, upstream_node_field, target=downstream_node_field)
-    G.add_nodes_from(zip(nodes.index, nodes.to_dict(orient='records')))
+
+    if nodes is not None:
+        G.add_nodes_from(zip(nodes.index, nodes.to_dict(orient='records')))
 
     # create geojson geometry objects for each graph element
     for u, v, k, coords in G.edges(data='coords', keys=True):

--- a/sewergraph/save_load.py
+++ b/sewergraph/save_load.py
@@ -4,10 +4,12 @@
 # License: MIT, see full license in LICENSE.txt
 # Web: https://github.com/aerispaha/sewergraph
 ################################################################################
+import warnings
 
-
+from geojson import Point, LineString
 import networkx as nx
 import pandas as pd
+
 from sewergraph import generate_facility_id
 
 
@@ -143,6 +145,60 @@ def graph_from_shp(pth=r'test_processed_01', idcol='facilityid', crs={'init': 'e
         if idcol not in d:
             d[idcol] = generate_facility_id()
 
+    return G
+
+
+def graph_from_gdfs(links, nodes=None, upstream_node_field='InletNode', downstream_node_field='OutletNode',
+                    drop_cycles=False):
+
+    '''
+    Networkx MultiDiGraph representation
+    '''
+
+    if nodes is not None and links.crs != nodes.crs:
+        raise ValueError(f'the coordinate reference system for links and nodes is inconsistent')
+
+    def multidigraph_from_edges(edges, source, target):
+        '''
+        create a MultiDiGraph from a dataframe of edges, using the row index
+        as the key in the MultiDiGraph
+        '''
+        us = edges[source]
+        vs = edges[target]
+        keys = edges.index
+        data = edges.drop([source, target], axis=1)
+        d_dicts = data.to_dict(orient='records')
+
+        G = nx.MultiDiGraph()
+
+        G.add_edges_from(zip(us, vs, keys, d_dicts))
+
+        return G
+
+    # parse swmm model results with swmmio, concat all links into one dataframe
+    links['facilityid'] = links.index
+
+    # create a nx.MultiDiGraph from the combined model links, add node data, set CRS
+    G = multidigraph_from_edges(links, upstream_node_field, target=downstream_node_field)
+    G.add_nodes_from(zip(nodes.index, nodes.to_dict(orient='records')))
+
+    # create geojson geometry objects for each graph element
+    for u, v, k, coords in G.edges(data='coords', keys=True):
+        if coords:
+            G[u][v][k]['geometry'] = LineString(coords)
+    for n, coords in G.nodes(data='coords'):
+        if coords:
+            G.nodes[n]['geometry'] = Point(coords[0])
+
+    if drop_cycles:
+        # remove cycles
+        cycles = list(nx.simple_cycles(G))
+        if len(cycles) > 0:
+            warnings.warn(f'cycles detected and removed: {cycles}')
+            G.remove_edges_from(cycles)
+
+    G = nx.convert_node_labels_to_integers(G, label_attribute='coords')
+    G.graph['crs'] = links.crs
     return G
 
 

--- a/sewergraph/tests/accumulation_test.py
+++ b/sewergraph/tests/accumulation_test.py
@@ -10,14 +10,14 @@ def test_downstream_accum():
 
     H = nx.DiGraph()
     H.add_edges_from([(5,4), (4,3), (6,3), (3,2), (2,1)])
-    H.node[5]['local_area'] = 1
-    H.node[4]['local_area'] = 1.75
-    H.node[3]['local_area'] = 1
+    H.nodes[5]['local_area'] = 1
+    H.nodes[4]['local_area'] = 1.75
+    H.nodes[3]['local_area'] = 1
 
     H[6][3]['local_area'] = 0.25
 
     H = sg.accumulate_downstream(H)
-    assert H.node[1]['cumulative_local_area'] == 4.0
+    assert H.nodes[1]['cumulative_local_area'] == 4.0
 
     #add a flow split
     H.add_edges_from([(1,0), (1, 'A')])
@@ -25,8 +25,8 @@ def test_downstream_accum():
     H[1]['A']['flow_split_frac'] = 0.75
     H = sg.accumulate_downstream(H, split_attr='flow_split_frac')
 
-    assert H.node[0]['cumulative_local_area'] == 1.0
-    assert H.node['A']['cumulative_local_area'] == 3.0
+    assert H.nodes[0]['cumulative_local_area'] == 1.0
+    assert H.nodes['A']['cumulative_local_area'] == 3.0
 
 
 # def test_identify_outfalls():
@@ -36,8 +36,8 @@ def test_downstream_accum():
 #
 #     H1 = sg.identify_outfalls(H)
 #
-#     assert (H1.node[2]['outfalls'] == ['outfall3', 'outfall2', 'outfall1'])
-#     assert (H1.node['b']['outfalls'] == ['outfall3', 'outfall2'])
+#     assert (H1.nodes[2]['outfalls'] == ['outfall3', 'outfall2', 'outfall1'])
+#     assert (H1.nodes['b']['outfalls'] == ['outfall3', 'outfall2'])
 
 
 def test_relative_outfall_contribution():
@@ -45,10 +45,10 @@ def test_relative_outfall_contribution():
     H.add_edges_from([('A','i'), ('B','i'), ('C','j'), ('D','k'),
                       ('i', 'j'), ('j','k'),  ('k','OF2')])
 
-    H.node['A']['local_area'] = 1.0
-    H.node['B']['local_area'] = 2.0
-    H.node['C']['local_area'] = 1.0
-    H.node['D']['local_area'] = 1.0
+    H.nodes['A']['local_area'] = 1.0
+    H.nodes['B']['local_area'] = 2.0
+    H.nodes['C']['local_area'] = 1.0
+    H.nodes['D']['local_area'] = 1.0
 
     #flow splits
     H.add_edges_from([('j','j1'), ('j1', 'OF1')])
@@ -60,9 +60,9 @@ def test_relative_outfall_contribution():
     H = sg.assign_inflow_ratio(H, inflow_attr='cumulative_area')
     H = sg.relative_outfall_contribution(H)
 
-    assert(H.node['B']['outfall_contrib'] == {'OF2': 0.4, 'OF1': 0.5})
-    assert(H.node['j']['outfall_contrib'] == {'OF2': 0.8, 'OF1': 1.0})
-    assert(H.node['k']['outfall_contrib'] == {'OF2': 1.0})
+    assert(H.nodes['B']['outfall_contrib'] == {'OF2': 0.4, 'OF1': 0.5})
+    assert(H.nodes['j']['outfall_contrib'] == {'OF2': 0.8, 'OF1': 1.0})
+    assert(H.nodes['k']['outfall_contrib'] == {'OF2': 1.0})
 
 
 def test_graph_from_shp():

--- a/sewergraph/tests/accumulation_test.py
+++ b/sewergraph/tests/accumulation_test.py
@@ -8,21 +8,21 @@ DATA_DIR = os.path.join(TEST_DIR, 'data')
 
 def test_downstream_accum():
 
-    H = nx.DiGraph()
+    H = nx.MultiDiGraph()
     H.add_edges_from([(5,4), (4,3), (6,3), (3,2), (2,1)])
     H.nodes[5]['local_area'] = 1
     H.nodes[4]['local_area'] = 1.75
     H.nodes[3]['local_area'] = 1
 
-    H[6][3]['local_area'] = 0.25
+    H[6][3][0]['local_area'] = 0.25
 
     H = sg.accumulate_downstream(H)
     assert H.nodes[1]['cumulative_local_area'] == 4.0
 
     #add a flow split
     H.add_edges_from([(1,0), (1, 'A')])
-    H[1][0]['flow_split_frac'] = 0.25
-    H[1]['A']['flow_split_frac'] = 0.75
+    H[1][0][0]['flow_split_frac'] = 0.25
+    H[1]['A'][0]['flow_split_frac'] = 0.75
     H = sg.accumulate_downstream(H, split_attr='flow_split_frac')
 
     assert H.nodes[0]['cumulative_local_area'] == 1.0
@@ -41,7 +41,7 @@ def test_downstream_accum():
 
 
 def test_relative_outfall_contribution():
-    H = nx.DiGraph()
+    H = nx.MultiDiGraph()
     H.add_edges_from([('A','i'), ('B','i'), ('C','j'), ('D','k'),
                       ('i', 'j'), ('j','k'),  ('k','OF2')])
 
@@ -52,8 +52,8 @@ def test_relative_outfall_contribution():
 
     #flow splits
     H.add_edges_from([('j','j1'), ('j1', 'OF1')])
-    H['j']['j1']['flow_split_frac'] = 0.25
-    H['j']['k']['flow_split_frac'] = 0.75
+    H['j']['j1'][0]['flow_split_frac'] = 0.25
+    H['j']['k'][0]['flow_split_frac'] = 0.75
 
     H = sg.accumulate_downstream(H, accum_attr='local_area',
                                  cumu_attr_name='cumulative_area')

--- a/sewergraph/tests/accumulation_test.py
+++ b/sewergraph/tests/accumulation_test.py
@@ -5,6 +5,7 @@ import os
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
 
+
 def test_downstream_accum():
 
     H = nx.DiGraph()
@@ -62,6 +63,7 @@ def test_relative_outfall_contribution():
     assert(H.node['B']['outfall_contrib'] == {'OF2': 0.4, 'OF1': 0.5})
     assert(H.node['j']['outfall_contrib'] == {'OF2': 0.8, 'OF1': 1.0})
     assert(H.node['k']['outfall_contrib'] == {'OF2': 1.0})
+
 
 def test_graph_from_shp():
 

--- a/sewergraph/tests/accumulation_test.py
+++ b/sewergraph/tests/accumulation_test.py
@@ -2,6 +2,8 @@ import networkx as nx
 import sewergraph as sg
 import os
 
+import pytest
+
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
 
@@ -65,6 +67,7 @@ def test_relative_outfall_contribution():
     assert(H.nodes['k']['outfall_contrib'] == {'OF2': 1.0})
 
 
+@pytest.mark.skip(reason="graph_from_shp is depreciated and doesn't support MultiDiGraph")
 def test_graph_from_shp():
 
     #read shapefile into DiGraph

--- a/sewergraph/tests/test_hhcalculations.py
+++ b/sewergraph/tests/test_hhcalculations.py
@@ -1,0 +1,13 @@
+import unittest
+
+from sewergraph import hhcalculations
+
+
+class TestHHCalculations(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+
+    def test_mannings_capacity(self):
+
+        q = hhcalculations.mannings_capacity(diameter=12, slope=0.02)
+        self.assertAlmostEqual(q, 4.3764, places=4)

--- a/sewergraph/tests/test_hhcalculations.py
+++ b/sewergraph/tests/test_hhcalculations.py
@@ -7,7 +7,11 @@ class TestHHCalculations(unittest.TestCase):
     def setUp(self) -> None:
         pass
 
-    def test_mannings_capacity(self):
+    def test_mannings_capacity_circle(self):
 
         q = hhcalculations.mannings_capacity(diameter=12, slope=0.02)
         self.assertAlmostEqual(q, 4.3764, places=4)
+
+    def test_mannings_capacity_box(self):
+        q = hhcalculations.mannings_capacity(diameter=None, slope=0.02, height=12, width=12, shape='BOX')
+        self.assertAlmostEqual(q, 5.5723, places=4)


### PR DESCRIPTION
## Summary 
These changes update all references to the networkx API for compatibility with the 2.x API. This includes many references to `G.node[n]` to `G.nodes[n]`. This also provides support for MultiDiGraph representations of sewer networks.

### highlights
- partially supports MultiDiGraph representations of sewer networks
- update internal refrences for networkx 2.x API

Closes #23 